### PR TITLE
Test working fmt versions

### DIFF
--- a/packages/darma-vt/package.py
+++ b/packages/darma-vt/package.py
@@ -158,7 +158,7 @@ class DarmaVt(CMakePackage):
     depends_on("mpi")
     depends_on("darma-magistrate+kokkos", when="+kokkos")
     depends_on("darma-magistrate~kokkos", when="~kokkos")
-    depends_on("fmt@7.1.3", when="@develop,1.5:")
+    depends_on("fmt@10.2.1", when="@develop,1.5:")
 
     sanity_check_is_dir = ["include/vt"]
     sanity_check_is_file = ["cmake/vtConfig.cmake", "cmake/vtTargets.cmake"]


### PR DESCRIPTION
This is not intended to be merged, but to run CI and see what `fmt` versions work to build the spack package.